### PR TITLE
Add mesh validation for STL and 3MF exports

### DIFF
--- a/cli/check-api-contracts.ts
+++ b/cli/check-api-contracts.ts
@@ -24,6 +24,7 @@ import {
   intersection2d,
   hull2d,
   runScript,
+  validateMeshExportObject,
   constrainedSketch,
   sketchRegions,
   sketchRegion,
@@ -159,6 +160,29 @@ function checkBooleanErrors(): void {
   assert.throws(
     () => union2d([plate, undefined as unknown as ReturnType<typeof rect>]),
     /union2d\(\) argument 2: expected a Sketch, got undefined/,
+  );
+}
+
+function checkMeshExportValidation(): void {
+  const connected = validateMeshExportObject({
+    name: 'connected box',
+    shape: box(10, 10, 10, true),
+  });
+  assert.equal(connected.connectedComponents, 1, 'single box should export as one connected component');
+  assert.equal(connected.nonManifoldEdges, 0, 'single box should not have non-manifold edges');
+  assert.deepEqual(connected.issues, [], 'single box should pass mesh export validation');
+
+  const disconnected = validateMeshExportObject({
+    name: 'disconnected union',
+    shape: union(
+      box(10, 10, 10, true),
+      box(10, 10, 10, true).translate(30, 0, 0),
+    ),
+  });
+  assert.equal(disconnected.connectedComponents, 2, 'disjoint union should remain detectable as disconnected mesh components');
+  assert(
+    disconnected.issues.some((issue) => issue.code === 'mesh.disconnected_components' && issue.severity === 'error'),
+    'disjoint union should fail mesh export validation',
   );
 }
 
@@ -506,6 +530,7 @@ export async function runCheckApiContractsCli(): Promise<void> {
   checkTrackedShapeInterop();
   checkSketchBooleanForms();
   checkBooleanErrors();
+  checkMeshExportValidation();
   checkEdgeFinishSubsetErrors();
   checkSheetMetalApiContracts();
   checkSandboxBindings();

--- a/cli/forge-mesh.ts
+++ b/cli/forge-mesh.ts
@@ -5,6 +5,7 @@ import {
   runScript,
   build3mfBuffer,
   buildBinaryStl,
+  validateMeshExportObjects,
   type MeshExportObject,
 } from '../src/forge/headless';
 import { initKernel, setActiveBackend, type ActiveBackend } from '../src/forge/kernel';
@@ -17,6 +18,7 @@ interface ParsedArgs {
   outputPath?: string;
   quality?: 'default' | 'live' | 'high';
   backend?: ActiveBackend;
+  validate?: boolean;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -24,6 +26,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let outputPath: string | undefined;
   let quality: 'default' | 'live' | 'high' | undefined;
   let backend: ActiveBackend | undefined;
+  let validate = false;
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -51,6 +54,10 @@ function parseArgs(argv: string[]): ParsedArgs {
       i += 1;
       continue;
     }
+    if (arg === '--validate') {
+      validate = true;
+      continue;
+    }
     if (arg.startsWith('--')) {
       throw new Error(`Unknown flag: ${arg}`);
     }
@@ -62,7 +69,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     throw new Error('Usage: forgecad export <3mf|stl> <script.forge.js> [--output path] [--quality default|live|high] [--backend manifold|occt]');
   }
 
-  return { scriptPath, outputPath, quality, backend };
+  return { scriptPath, outputPath, quality, backend, validate };
 }
 
 function defaultOutputPath(scriptPath: string, format: MeshFormat): string {
@@ -83,11 +90,27 @@ function extractMeshObjects(result: ReturnType<typeof runScript>): MeshExportObj
     }));
 }
 
+function printMeshValidationReports(reports: ReturnType<typeof validateMeshExportObjects>): void {
+  console.log('  Mesh validation:');
+  reports.forEach((report) => {
+    console.log(
+      `    ${report.name}: ${report.vertices.toLocaleString()} vertices, ` +
+      `${report.triangles.toLocaleString()} triangles, ` +
+      `${report.connectedComponents.toLocaleString()} component(s), ` +
+      `${report.nonManifoldEdges.toLocaleString()} non-manifold edge(s)`,
+    );
+    report.issues.forEach((issue) => {
+      const prefix = issue.severity === 'error' ? 'ERROR' : 'WARN';
+      console.log(`      ${prefix} ${issue.code}: ${issue.message}`);
+    });
+  });
+}
+
 export async function runMeshExportCli(
   format: MeshFormat,
   argv: string[],
 ): Promise<void> {
-  const { scriptPath, outputPath, quality, backend } = parseArgs(argv);
+  const { scriptPath, outputPath, quality, backend, validate } = parseArgs(argv);
   const code = (await import('fs')).readFileSync(resolve(scriptPath), 'utf-8');
   const { allFiles, fileName, readBinaryFile } = collectProjectFiles(scriptPath);
 
@@ -105,6 +128,18 @@ export async function runMeshExportCli(
   if (meshObjects.length === 0) {
     console.error('No 3D shapes found in the script output.');
     process.exit(2);
+  }
+
+  const validationReports = validate ? validateMeshExportObjects(meshObjects) : [];
+  const validationFailures = validationReports.flatMap((report) =>
+    report.issues
+      .filter((issue) => issue.severity === 'error')
+      .map((issue) => `${report.name}: ${issue.message}`),
+  );
+  if (validationFailures.length > 0) {
+    printMeshValidationReports(validationReports);
+    console.error(`Mesh validation failed:\n${validationFailures.map((failure) => `  - ${failure}`).join('\n')}`);
+    process.exit(3);
   }
 
   const target = resolve(outputPath ?? defaultOutputPath(scriptPath, format));
@@ -130,4 +165,7 @@ export async function runMeshExportCli(
   console.log(`✓ Exported ${format.toUpperCase()} to ${target}`);
   console.log(`  ${meshObjects.length} object(s)${quality ? ` [quality: ${quality}]` : ''}`);
   stats.forEach((line) => console.log(line));
+  if (validate) {
+    printMeshValidationReports(validationReports);
+  }
 }

--- a/cli/forgecad.ts
+++ b/cli/forgecad.ts
@@ -547,18 +547,20 @@ const commands: CommandDefinition[] = [
     path: ['export', '3mf'],
     summary: 'Export a Forge script to 3MF (3D Manufacturing Format) for 3D printing.',
     usage: [
-      'forgecad export 3mf <script.forge.js> [--output path] [--quality default|live|high] [--backend manifold|occt]',
+      'forgecad export 3mf <script.forge.js> [--output path] [--quality default|live|high] [--backend manifold|occt] [--validate]',
     ],
     examples: [
       'forgecad export 3mf examples/cup.forge.js',
       'forgecad export 3mf examples/cup.forge.js --output out/cup.3mf',
       'forgecad export 3mf examples/cup.forge.js --quality high',
+      'forgecad export 3mf examples/cup.forge.js --validate',
     ],
     completion: {
       options: [
         { name: '--output', description: 'Output 3MF path', argument: 'required', valueLabel: '<path>', valueKind: 'path' },
         { name: '--quality', description: 'Forge quality preset', argument: 'required', valueLabel: '<default|live|high>', values: QUALITY_VALUES },
         { name: '--backend', description: 'Geometry backend', argument: 'required', valueLabel: '<manifold|occt>', values: [{ value: 'manifold', description: 'Manifold backend (default)' }, { value: 'occt', description: 'OCCT backend' }] },
+        { name: '--validate', description: 'Fail export when the mesh has non-manifold edges, degenerate triangles, or disconnected components' },
       ],
       positionals: [
         { description: 'Forge script', valueKind: 'forge-script' },
@@ -571,18 +573,20 @@ const commands: CommandDefinition[] = [
     path: ['export', 'stl'],
     summary: 'Export a Forge script to binary STL.',
     usage: [
-      'forgecad export stl <script.forge.js> [--output path] [--quality default|live|high] [--backend manifold|occt]',
+      'forgecad export stl <script.forge.js> [--output path] [--quality default|live|high] [--backend manifold|occt] [--validate]',
     ],
     examples: [
       'forgecad export stl examples/cup.forge.js',
       'forgecad export stl examples/cup.forge.js --output out/cup.stl',
       'forgecad export stl examples/cup.forge.js --quality high',
+      'forgecad export stl examples/cup.forge.js --validate',
     ],
     completion: {
       options: [
         { name: '--output', description: 'Output STL path', argument: 'required', valueLabel: '<path>', valueKind: 'path' },
         { name: '--quality', description: 'Forge quality preset', argument: 'required', valueLabel: '<default|live|high>', values: QUALITY_VALUES },
         { name: '--backend', description: 'Geometry backend', argument: 'required', valueLabel: '<manifold|occt>', values: [{ value: 'manifold', description: 'Manifold backend (default)' }, { value: 'occt', description: 'OCCT backend' }] },
+        { name: '--validate', description: 'Fail export when the mesh has non-manifold edges, degenerate triangles, or disconnected components' },
       ],
       positionals: [
         { description: 'Forge script', valueKind: 'forge-script' },

--- a/src/forge/exportMesh.ts
+++ b/src/forge/exportMesh.ts
@@ -13,6 +13,28 @@ export interface ThreeMfExportOptions {
   description?: string;
 }
 
+export interface MeshExportValidationIssue {
+  severity: 'warning' | 'error';
+  code:
+    | 'mesh.no_triangles'
+    | 'mesh.degenerate_triangle'
+    | 'mesh.duplicate_triangle'
+    | 'mesh.non_manifold_edge'
+    | 'mesh.disconnected_components';
+  message: string;
+}
+
+export interface MeshExportValidationReport {
+  name: string;
+  triangles: number;
+  vertices: number;
+  connectedComponents: number;
+  nonManifoldEdges: number;
+  degenerateTriangles: number;
+  duplicateTriangles: number;
+  issues: MeshExportValidationIssue[];
+}
+
 interface RGB {
   r: number;
   g: number;
@@ -59,6 +81,137 @@ function toRGB555(colorHex: string): number {
 function rgbToHex(r: number, g: number, b: number): string {
   const toHex = (v: number) => v.toString(16).padStart(2, '0').toUpperCase();
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function vertexKey(mesh: ReturnType<Shape['getMesh']>, index: number): string {
+  const offset = index * mesh.numProp;
+  return `${mesh.vertProperties[offset]},${mesh.vertProperties[offset + 1]},${mesh.vertProperties[offset + 2]}`;
+}
+
+function triangleAreaSquared(mesh: ReturnType<Shape['getMesh']>, i0: number, i1: number, i2: number): number {
+  const a = i0 * mesh.numProp;
+  const b = i1 * mesh.numProp;
+  const c = i2 * mesh.numProp;
+  const abx = mesh.vertProperties[b] - mesh.vertProperties[a];
+  const aby = mesh.vertProperties[b + 1] - mesh.vertProperties[a + 1];
+  const abz = mesh.vertProperties[b + 2] - mesh.vertProperties[a + 2];
+  const acx = mesh.vertProperties[c] - mesh.vertProperties[a];
+  const acy = mesh.vertProperties[c + 1] - mesh.vertProperties[a + 1];
+  const acz = mesh.vertProperties[c + 2] - mesh.vertProperties[a + 2];
+  const nx = aby * acz - abz * acy;
+  const ny = abz * acx - abx * acz;
+  const nz = abx * acy - aby * acx;
+  return nx * nx + ny * ny + nz * nz;
+}
+
+function countConnectedComponents(vertexCount: number, adjacency: Map<number, Set<number>>): number {
+  const seen = new Set<number>();
+  let components = 0;
+
+  for (let vertex = 0; vertex < vertexCount; vertex += 1) {
+    if (seen.has(vertex)) continue;
+    components += 1;
+    const stack = [vertex];
+    seen.add(vertex);
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      for (const next of adjacency.get(current) ?? []) {
+        if (seen.has(next)) continue;
+        seen.add(next);
+        stack.push(next);
+      }
+    }
+  }
+
+  return components;
+}
+
+export function validateMeshExportObject(obj: MeshExportObject): MeshExportValidationReport {
+  const mesh = obj.shape.getMesh();
+  const vertexCount = Math.floor(mesh.vertProperties.length / mesh.numProp);
+  const edgeUse = new Map<string, number>();
+  const triangleUse = new Set<string>();
+  const adjacency = new Map<number, Set<number>>();
+  let degenerateTriangles = 0;
+  let duplicateTriangles = 0;
+
+  const addEdge = (a: number, b: number): void => {
+    const key = a < b ? `${a}:${b}` : `${b}:${a}`;
+    edgeUse.set(key, (edgeUse.get(key) ?? 0) + 1);
+    if (!adjacency.has(a)) adjacency.set(a, new Set());
+    if (!adjacency.has(b)) adjacency.set(b, new Set());
+    adjacency.get(a)!.add(b);
+    adjacency.get(b)!.add(a);
+  };
+
+  for (let tri = 0; tri < mesh.numTri; tri += 1) {
+    const i0 = mesh.triVerts[tri * 3];
+    const i1 = mesh.triVerts[tri * 3 + 1];
+    const i2 = mesh.triVerts[tri * 3 + 2];
+
+    if (i0 === i1 || i1 === i2 || i2 === i0 || triangleAreaSquared(mesh, i0, i1, i2) <= 1e-18) {
+      degenerateTriangles += 1;
+    }
+
+    const triangleKey = [vertexKey(mesh, i0), vertexKey(mesh, i1), vertexKey(mesh, i2)].sort().join('|');
+    if (triangleUse.has(triangleKey)) duplicateTriangles += 1;
+    triangleUse.add(triangleKey);
+
+    addEdge(i0, i1);
+    addEdge(i1, i2);
+    addEdge(i2, i0);
+  }
+
+  const nonManifoldEdges = [...edgeUse.values()].filter((count) => count !== 2).length;
+  const connectedComponents = countConnectedComponents(vertexCount, adjacency);
+  const issues: MeshExportValidationIssue[] = [];
+
+  if (mesh.numTri === 0) {
+    issues.push({ severity: 'error', code: 'mesh.no_triangles', message: 'mesh has no triangles' });
+  }
+  if (degenerateTriangles > 0) {
+    issues.push({
+      severity: 'error',
+      code: 'mesh.degenerate_triangle',
+      message: `${degenerateTriangles.toLocaleString()} degenerate triangle(s)`,
+    });
+  }
+  if (duplicateTriangles > 0) {
+    issues.push({
+      severity: 'warning',
+      code: 'mesh.duplicate_triangle',
+      message: `${duplicateTriangles.toLocaleString()} duplicate triangle(s)`,
+    });
+  }
+  if (nonManifoldEdges > 0) {
+    issues.push({
+      severity: 'error',
+      code: 'mesh.non_manifold_edge',
+      message: `${nonManifoldEdges.toLocaleString()} non-manifold edge(s)`,
+    });
+  }
+  if (connectedComponents > 1) {
+    issues.push({
+      severity: 'error',
+      code: 'mesh.disconnected_components',
+      message: `${connectedComponents.toLocaleString()} disconnected component(s)`,
+    });
+  }
+
+  return {
+    name: obj.name,
+    triangles: mesh.numTri,
+    vertices: vertexCount,
+    connectedComponents,
+    nonManifoldEdges,
+    degenerateTriangles,
+    duplicateTriangles,
+    issues,
+  };
+}
+
+export function validateMeshExportObjects(objects: MeshExportObject[]): MeshExportValidationReport[] {
+  return objects.map(validateMeshExportObject);
 }
 
 /**

--- a/src/forge/headless.ts
+++ b/src/forge/headless.ts
@@ -151,8 +151,13 @@ export type {
   ReportGenerationResult,
 } from './report';
 
-export { build3mfBuffer, buildBinaryStl } from './exportMesh';
-export type { MeshExportObject, ThreeMfExportOptions } from './exportMesh';
+export { build3mfBuffer, buildBinaryStl, validateMeshExportObjects, validateMeshExportObject } from './exportMesh';
+export type {
+  MeshExportObject,
+  ThreeMfExportOptions,
+  MeshExportValidationIssue,
+  MeshExportValidationReport,
+} from './exportMesh';
 
 /**
  * Initialize the geometry kernel. Must be called once before using any forge API.


### PR DESCRIPTION
## Summary
- add reusable mesh export validation for STL/3MF exports
- add `--validate` to `forgecad export stl` and `forgecad export 3mf`
- fail before writing output when exported mesh objects contain non-manifold edges, degenerate triangles, or disconnected components
- add API contract coverage for connected and disconnected mesh validation

## Context
This catches cases where ForgeCAD can produce an STL/3MF file that appears to export successfully but is later rejected by slicers because the exported mesh is not printable/manifold.

## Validation
- `npm run build:cli`
- `node dist-cli/forgecad.js export stl examples/api/group-vs-union.forge.js --output /tmp/forgecad-group-vs-union.stl --validate` exits 0 and writes output
- `node dist-cli/forgecad.js export stl examples/api/colors-union-vs-array.forge.js --output /tmp/forgecad-colors-union-vs-array.stl --validate` exits 3 and does not write output
- `git diff --check`

Note: full `npm run test:prepare` was not run locally because this machine does not have Rust/cargo/wasm-pack installed, so `solver/pkg/solver.js` cannot be generated here.